### PR TITLE
[HOLD] Added Travis-CI build and deploy.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "node": true,
+  "predef": [ "window" ],
+  "esversion": 6
+}

--- a/bin/stache
+++ b/bin/stache
@@ -19,6 +19,7 @@ var args,
 function getBase(args, cli, cwd) {
     var isCLI = false,
         tasks = [
+            'bump',
             'cliversion',
             'copyBuild',
             'deploy',

--- a/bin/stache
+++ b/bin/stache
@@ -19,9 +19,9 @@ var args,
 function getBase(args, cli, cwd) {
     var isCLI = false,
         tasks = [
-            'bump',
             'cliversion',
             'copyBuild',
+            'release',
             'deploy',
             'new'
         ];

--- a/bin/stache
+++ b/bin/stache
@@ -20,6 +20,7 @@ function getBase(args, cli, cwd) {
     var isCLI = false,
         tasks = [
             'cliversion',
+            'copyBuild',
             'deploy',
             'new'
         ];

--- a/bin/stache
+++ b/bin/stache
@@ -19,12 +19,11 @@ var args,
 function getBase(args, cli, cwd) {
     var isCLI = false,
         tasks = [
-            'bump',
             'cliversion',
             'copyBuild',
-            'release',
             'deploy',
-            'new'
+            'new',
+            'release'
         ];
     if (args && args.length > 2) {
         tasks.forEach(function (task) {

--- a/bin/stache
+++ b/bin/stache
@@ -19,6 +19,7 @@ var args,
 function getBase(args, cli, cwd) {
     var isCLI = false,
         tasks = [
+            'bump',
             'cliversion',
             'copyBuild',
             'release',

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -89,7 +89,7 @@ module.exports = function (grunt) {
                 tagName: 'v%VERSION%',
                 tagMessage: 'Version %VERSION%',
                 push: true,
-                pushTo: 'upstream',
+                pushTo: 'origin',
                 gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
                 globalReplace: false,
                 prereleaseName: false,

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -74,9 +74,9 @@ module.exports = function (grunt) {
         'Create a new release branch and commit to upstream.',
         function (type) {
             type = type || 'patch';
-            console.log(type);
             exec('grunt --base ' + grunt.option('cwd') + ' bump:' + type, {
-                cwd: path.resolve()
+                cwd: path.resolve(),
+                stdio: 'inherit'
             });
         }
     );

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -74,7 +74,8 @@ module.exports = function (grunt) {
         'Create a new release branch and commit to upstream.',
         function (type) {
             type = type || 'patch';
-            exec('grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type, {
+            console.log('Executing... `grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type + '`');
+            exec('git status && grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type, {
                 cwd: path.resolve()
             });
         }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,6 +2,7 @@ module.exports = function (grunt) {
     'use strict';
 
     var path = require('path');
+    var exec = require('child_process').execSync;
 
     function taskCliVersion() {
         grunt.log.writeln('Current stache-cli version: ' + grunt.file.readJSON('package.json').version);
@@ -71,9 +72,9 @@ module.exports = function (grunt) {
     grunt.registerTask(
         'release',
         'Create a new release branch and commit to upstream.',
-        [
-            'shell:release'
-        ]
+        function (a, b, c) {
+            console.log(a, b, c);
+        }
     );
 
     // Configure necessary modules
@@ -106,7 +107,7 @@ module.exports = function (grunt) {
             },
             copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
             deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh',
-            release: 'echo "Hello, World!" && grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump',
+            bump: 'grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump',
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -24,6 +24,11 @@ module.exports = function (grunt) {
         }
     }
 
+    // Load necessary modules
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-bump');
+    grunt.loadNpmTasks('grunt-shell');
+
     // Register our tasks
     grunt.registerTask(
         'cliversion',
@@ -61,12 +66,27 @@ module.exports = function (grunt) {
         taskNew
     );
 
-    // Load necessary modules
-    grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-shell');
-
     // Configure necessary modules
     grunt.config.init({
+        bump: {
+            options: {
+                files: ['package.json'],
+                updateConfigs: [],
+                commit: true,
+                commitMessage: 'Release v%VERSION%',
+                commitFiles: ['package.json'],
+                createTag: true,
+                tagName: 'v%VERSION%',
+                tagMessage: 'Version %VERSION%',
+                push: true,
+                pushTo: 'upstream',
+                gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+                globalReplace: false,
+                prereleaseName: false,
+                metadata: '',
+                regExp: false
+            }
+        },
         shell: {
             options: {
                 execOptions: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -74,8 +74,7 @@ module.exports = function (grunt) {
         'Create a new release branch and commit to upstream.',
         function (type) {
             type = type || 'patch';
-            console.log('Executing... `grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type + '`');
-            exec('git status && grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type, {
+            exec('grunt --base ' + grunt.option('cwd') + ' bump:' + type, {
                 cwd: path.resolve()
             });
         }
@@ -110,8 +109,7 @@ module.exports = function (grunt) {
                 }
             },
             copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
-            deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh',
-            bump: 'grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump',
+            deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh'
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -52,10 +52,7 @@ module.exports = function (grunt) {
     'copyBuild',
     'Copies the results of a Travis-CI build to the deploy branch',
     function () {
-      var path = require('path');
-      var cwd = process.cwd();
-      console.log(cwd, path.resolve());
-      var config = grunt.file.readYAML(path.resolve() + '/' + grunt.option('config'));
+      var config = grunt.file.readYAML(grunt.option('config'));
       var envStr = '';
       for (var k in config.env) {
         if (config.env.hasOwnProperty(k)) {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -55,7 +55,9 @@ module.exports = function (grunt) {
       var config = grunt.file.readYAML(grunt.option('config'));
       var envStr = '';
       for (var k in config.env) {
-        envStr += k + '=' config.env[k];
+        if (config.env.hasOwnProperty(k)) {
+          envStr += k + '=' + config.env[k];
+        }
       }
       console.log("ENV: ", envStr);
       exec(envStr + ' bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -69,8 +69,7 @@ module.exports = function (grunt) {
         envStr += ' ';
       }
 
-      grunt.option('envStr', envStr);
-      grunt.task.run('shell:copyBuild');
+      grunt.task.run('shell:copyBuild:' + envStr);
     }
   );
 
@@ -139,7 +138,11 @@ module.exports = function (grunt) {
           stdout: true
         }
       },
-      copyBuild: grunt.option('envStr') + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
+      copyBuild: {
+        command: function (env) {
+          return env + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh';
+        }
+      },
       deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh'
     }
   });

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -72,8 +72,8 @@ module.exports = function (grunt) {
     grunt.registerTask(
         'release',
         'Create a new release branch and commit to upstream.',
-        function (a, b, c) {
-            console.log(a, b, c);
+        function (type) {
+            exec('grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type || 'patch');
         }
     );
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function (grunt) {
                 commit: true,
                 commitMessage: 'Release v%VERSION%',
                 commitFiles: ['package.json'],
-                createTag: true,
+                createTag: false,
                 tagName: 'v%VERSION%',
                 tagMessage: 'Version %VERSION%',
                 push: true,

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
     // Register our tasks
     grunt.registerTask(
         'cliversion',
-        'Display the current installed cli version.',
+        'Displays the current installed cli version',
         taskCliVersion
     );
 
@@ -37,6 +37,15 @@ module.exports = function (grunt) {
         [
             'cliversion',
             'shell:deploy'
+        ]
+    );
+
+    grunt.registerTask(
+        'copyBuild',
+        'Copies the results of a Travis-CI build to the deploy branch',
+        [
+            'cliversion',
+            'shell:copyBuild'
         ]
     );
 
@@ -65,7 +74,8 @@ module.exports = function (grunt) {
                     stdout: true
                 }
             },
-            deploy: 'bash ' + grunt.option('cli') + 'deploy/deploy.sh'
+            copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
+            deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh'
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -57,19 +57,22 @@ module.exports = function (grunt) {
           k;
 
       filePath = grunt.option('config');
+      config = grunt.file.readYAML('stache.deploy.yml');
       env = [];
 
-      if (filePath) {
-        config = grunt.file.readYAML(filePath);
-        console.log("CONFIG:", config);
-        for (k in config.env) {
-          if (config.env.hasOwnProperty(k)) {
-            env.push(k + '=' + config.env[k]);
-          }
-        }
-        env = env.join(' ') + ' ';
+      if (filePath && grunt.file.exists(file)) {
+        config = merge.recursive(true, config, grunt.file.readYAML(file));
       }
 
+      console.log("CONFIG:", config);
+      
+      for (k in config.env) {
+        if (config.env.hasOwnProperty(k)) {
+          env.push(k + '=' + config.env[k]);
+        }
+      }
+
+      env = env.join(' ') + ' ';
       grunt.task.run('shell:copyBuild:' + env);
     }
   );

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function (grunt) {
   // Load necessary modules
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-bump');
-  //grunt.loadNpmTasks('grun-shell');
+  grunt.loadNpmTasks('grun-shell');
 
   // Register our tasks
   grunt.registerTask(
@@ -41,36 +41,36 @@ module.exports = function (grunt) {
   grunt.registerTask(
     'deploy',
     'Deploys the current project',
-    function () {
-      exec('bash ' + grunt.option('cli') + 'scripts/deploy.sh', {
-        cwd: path.resolve(),
-        stdio: 'inherit'
-      });
-    }
+    [
+      'cliversion',
+      'shell:deploy'
+    ]
   );
 
   grunt.registerTask(
     'copyBuild',
     'Copies the results of a Travis-CI build to the deploy branch',
     function () {
-      var filePath = grunt.option('config');
-      var envStr = '';
+      var config,
+          envStr,
+          filePath,
+          k;
+
+      filePath = grunt.option('config');
+      envStr = '';
+
       if (filePath) {
-        var config = grunt.file.readYAML(filePath);
-        for (var k in config.env) {
+        config = grunt.file.readYAML(filePath);
+        for (k in config.env) {
           if (config.env.hasOwnProperty(k)) {
             envStr += k + '=' + config.env[k];
           }
         }
         envStr += ' ';
       }
-      console.log("ENV: ", envStr);
-      console.log("Typeof:", typeof exec);
-      exec('echo "Hello, World!"');
-      exec(envStr + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
-        cwd: path.resolve(),
-        stdio: 'inherit'
-      });
+
+      grunt.option('envStr', envStr);
+      grunt.task.run('shell:copyBuild');
     }
   );
 
@@ -139,7 +139,8 @@ module.exports = function (grunt) {
           stdout: true
         }
       },
-      deploy: 'bash ' + grunt.option('cli') + 'deploy/deploy.sh'
+      copyBuild: grunt.option('envStr') + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
+      deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh'
     }
   });
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -74,6 +74,7 @@ module.exports = function (grunt) {
         'Create a new release branch and commit to upstream.',
         function (type) {
             type = type || 'patch';
+            console.log(type);
             exec('grunt --base ' + grunt.option('cwd') + ' bump:' + type, {
                 cwd: path.resolve()
             });

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -106,7 +106,7 @@ module.exports = function (grunt) {
             },
             copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
             deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh',
-            release: 'echo "Hello, World!" && grunt --gruntfile ' + path.resolve() + 'gruntfile.js bump',
+            release: 'echo "Hello, World!" && grunt --gruntfile ' + path.resolve() + '/gruntfile.js bump',
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
     'copyBuild',
     'Copies the results of a Travis-CI build to the deploy branch',
     function (arg) {
-      console.log(arg, this);
+      console.log(arg, JSON.stringify(this));
       exec('bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
         cwd: path.resolve(),
         stdio: 'inherit'

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,6 +2,7 @@ module.exports = function (grunt) {
 
   var path = require('path');
   var exec = require('child_process').execSync;
+  var merge = require('merge');
 
   function taskCliVersion() {
     grunt.log.writeln('Current stache-cli version: ' + grunt.file.readJSON('package.json').version);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -52,24 +52,24 @@ module.exports = function (grunt) {
     'Copies the results of a Travis-CI build to the deploy branch',
     function () {
       var config,
-          envStr,
+          env,
           filePath,
           k;
 
       filePath = grunt.option('config');
-      envStr = '';
+      env = [];
 
       if (filePath) {
         config = grunt.file.readYAML(filePath);
         for (k in config.env) {
           if (config.env.hasOwnProperty(k)) {
-            envStr += k + '=' + config.env[k];
+            env.push(k + '=' + config.env[k]);
           }
         }
-        envStr += ' ';
+        env = env.join(' ') + ' ';
       }
 
-      grunt.task.run('shell:copyBuild:' + envStr);
+      grunt.task.run('shell:copyBuild:' + env);
     }
   );
 
@@ -140,6 +140,7 @@ module.exports = function (grunt) {
       },
       copyBuild: {
         command: function (env) {
+          console.log("ENV vars: ", env);
           return env + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh';
         }
       },

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -54,8 +54,8 @@ module.exports = function (grunt) {
     function () {
       var path = require('path');
       var cwd = process.cwd();
-      console.log(cwd);
-      var config = grunt.file.readYAML(path + '/' + grunt.option('config'));
+      console.log(cwd, path.resolve());
+      var config = grunt.file.readYAML(path.resolve() + '/' + grunt.option('config'));
       var envStr = '';
       for (var k in config.env) {
         if (config.env.hasOwnProperty(k)) {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,6 +1,8 @@
 module.exports = function (grunt) {
     'use strict';
 
+    var path = require('path');
+
     function taskCliVersion() {
         grunt.log.writeln('Current stache-cli version: ' + grunt.file.readJSON('package.json').version);
     }
@@ -104,7 +106,7 @@ module.exports = function (grunt) {
             },
             copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
             deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh',
-            release: 'echo "Hello, World!" && grunt bump',
+            release: 'echo "Hello, World!" && grunt --gruntfile ' + path.resolve() + 'gruntfile.js bump',
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -70,8 +70,7 @@ module.exports = function (grunt) {
         'release',
         'Create a new release branch and commit to upstream.',
         [
-            'shell:release',
-            'bump'
+            'shell:release'
         ]
     );
 
@@ -105,7 +104,7 @@ module.exports = function (grunt) {
             },
             copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
             deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh',
-            release: 'echo "Hello, World!"',
+            release: 'echo "Hello, World!" && grunt bump',
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -52,15 +52,19 @@ module.exports = function (grunt) {
     'copyBuild',
     'Copies the results of a Travis-CI build to the deploy branch',
     function () {
-      var config = grunt.file.readYAML(grunt.option('config'));
+      var filePath = grunt.option('config');
       var envStr = '';
-      for (var k in config.env) {
-        if (config.env.hasOwnProperty(k)) {
-          envStr += k + '=' + config.env[k];
+      if (filePath) {
+        var config = grunt.file.readYAML(filePath);
+        for (var k in config.env) {
+          if (config.env.hasOwnProperty(k)) {
+            envStr += k + '=' + config.env[k];
+          }
         }
+        envStr += ' ';
       }
       console.log("ENV: ", envStr);
-      exec(envStr + ' bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
+      exec(envStr + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
         cwd: path.resolve(),
         stdio: 'inherit'
       });

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
   grunt.registerTask(
     'deploy',
     'Deploys the current project',
-    function (arg) {
+    function () {
       exec('bash ' + grunt.option('cli') + 'scripts/deploy.sh', {
         cwd: path.resolve(),
         stdio: 'inherit'
@@ -51,9 +51,14 @@ module.exports = function (grunt) {
   grunt.registerTask(
     'copyBuild',
     'Copies the results of a Travis-CI build to the deploy branch',
-    function (arg) {
-      console.log(arg, JSON.stringify(this));
-      exec('bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
+    function () {
+      var config = grunt.file.readYAML(grunt.option('config'));
+      var envStr = '';
+      for (var k in config.env) {
+        envStr += k + '=' config.env[k];
+      }
+      console.log("ENV: ", envStr);
+      exec(envStr + ' bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
         cwd: path.resolve(),
         stdio: 'inherit'
       });

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -52,7 +52,9 @@ module.exports = function (grunt) {
     'copyBuild',
     'Copies the results of a Travis-CI build to the deploy branch',
     function () {
-      var config = grunt.file.readYAML(grunt.option('config'));
+      var cwd = process.cwd();
+      console.log(cwd);
+      var config = grunt.file.readYAML(cwd + grunt.option('config'));
       var envStr = '';
       for (var k in config.env) {
         if (config.env.hasOwnProperty(k)) {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -60,12 +60,12 @@ module.exports = function (grunt) {
       config = grunt.file.readYAML('stache.deploy.yml');
       env = [];
 
-      if (filePath && grunt.file.exists(file)) {
-        config = merge.recursive(true, config, grunt.file.readYAML(file));
+      if (filePath && grunt.file.exists(filePath)) {
+        config = merge.recursive(true, config, grunt.file.readYAML(filePath));
       }
 
       console.log("CONFIG:", config);
-      
+
       for (k in config.env) {
         if (config.env.hasOwnProperty(k)) {
           env.push(k + '=' + config.env[k]);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -52,9 +52,10 @@ module.exports = function (grunt) {
     'copyBuild',
     'Copies the results of a Travis-CI build to the deploy branch',
     function () {
+      var path = require('path');
       var cwd = process.cwd();
       console.log(cwd);
-      var config = grunt.file.readYAML(cwd + grunt.option('config'));
+      var config = grunt.file.readYAML(path + '/' + grunt.option('config'));
       var envStr = '';
       for (var k in config.env) {
         if (config.env.hasOwnProperty(k)) {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -73,7 +73,10 @@ module.exports = function (grunt) {
         'release',
         'Create a new release branch and commit to upstream.',
         function (type) {
-            exec('grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type || 'patch');
+            type = type || 'patch';
+            exec('grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump:' + type, {
+                cwd: path.resolve()
+            });
         }
     );
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -66,6 +66,14 @@ module.exports = function (grunt) {
         taskNew
     );
 
+    grunt.registerTask(
+        'release',
+        'Create a new release branch and commit to upstream.',
+        [
+            'shell:release'
+        ]
+    );
+
     // Configure necessary modules
     grunt.config.init({
         bump: {
@@ -95,7 +103,8 @@ module.exports = function (grunt) {
                 }
             },
             copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
-            deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh'
+            deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh',
+            release: 'echo "Hello, World!"',
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -12,6 +12,19 @@ module.exports = function (grunt) {
   }
 
   function taskCopyBuild() {
+    var env;
+    env = getConfigEnvironmentString();
+    grunt.task.run('shell:copyBuild:' + env);
+  }
+
+  function taskDeploy() {
+    var env;
+    env = getConfigEnvironmentString();
+    grunt.task.run('cliversion');
+    grunt.task.run('shell:deploy:' + env);
+  }
+
+  function getConfigEnvironmentString() {
     var config,
         env,
         filePath,
@@ -33,8 +46,7 @@ module.exports = function (grunt) {
       }
     }
     env = env.join(' ') + ' ';
-
-    grunt.task.run('shell:copyBuild:' + env);
+    return env;
   }
 
   function taskFixIgnore() {
@@ -79,10 +91,7 @@ module.exports = function (grunt) {
   grunt.registerTask(
     'deploy',
     'Deploys the current project',
-    [
-      'cliversion',
-      'shell:deploy'
-    ]
+    taskDeploy
   );
 
   grunt.registerTask(
@@ -155,7 +164,11 @@ module.exports = function (grunt) {
           return env + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh';
         }
       },
-      deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh'
+      deploy: {
+        command: function (env) {
+          return env + 'bash ' + grunt.option('cli') + 'scripts/deploy.sh';
+        }
+      }
     }
   });
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,8 +1,11 @@
 module.exports = function (grunt) {
+  var exec,
+      merge,
+      path;
 
-  var path = require('path');
-  var exec = require('child_process').execSync;
-  var merge = require('merge');
+  path = require('path');
+  exec = require('child_process').execSync;
+  merge = require('merge');
 
   function taskCliVersion() {
     grunt.log.writeln('Current stache-cli version: ' + grunt.file.readJSON('package.json').version);
@@ -61,19 +64,19 @@ module.exports = function (grunt) {
       config = grunt.file.readYAML('stache.deploy.yml');
       env = [];
 
+      // Merge deployment config.
       if (filePath && grunt.file.exists(filePath)) {
         config = merge.recursive(true, config, grunt.file.readYAML(filePath));
       }
 
-      console.log("CONFIG:", config);
-
+      // Create a string of environment variables.
       for (k in config.env) {
         if (config.env.hasOwnProperty(k)) {
           env.push(k + '=' + config.env[k]);
         }
       }
-
       env = env.join(' ') + ' ';
+
       grunt.task.run('shell:copyBuild:' + env);
     }
   );
@@ -145,7 +148,6 @@ module.exports = function (grunt) {
       },
       copyBuild: {
         command: function (env) {
-          console.log("ENV vars: ", env);
           return env + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh';
         }
       },

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
   // Load necessary modules
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-bump');
+  //grunt.loadNpmTasks('grun-shell');
 
   // Register our tasks
   grunt.registerTask(
@@ -64,6 +65,7 @@ module.exports = function (grunt) {
         envStr += ' ';
       }
       console.log("ENV: ", envStr);
+      exec('echo "Hello, World!"');
       exec(envStr + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
         cwd: path.resolve(),
         stdio: 'inherit'
@@ -128,6 +130,15 @@ module.exports = function (grunt) {
           }
         ]
       }
+    },
+    shell: {
+      options: {
+        execOptions: {
+          cwd: grunt.option('cwd'),
+          stdout: true
+        }
+      },
+      deploy: 'bash ' + grunt.option('cli') + 'deploy/deploy.sh'
     }
   });
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function (grunt) {
   // Load necessary modules
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-bump');
-  grunt.loadNpmTasks('grun-shell');
+  grunt.loadNpmTasks('grunt-shell');
 
   // Register our tasks
   grunt.registerTask(

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,129 +1,122 @@
 module.exports = function (grunt) {
-    'use strict';
 
-    var path = require('path');
-    var exec = require('child_process').execSync;
+  var path = require('path');
+  var exec = require('child_process').execSync;
 
-    function taskCliVersion() {
-        grunt.log.writeln('Current stache-cli version: ' + grunt.file.readJSON('package.json').version);
+  function taskCliVersion() {
+    grunt.log.writeln('Current stache-cli version: ' + grunt.file.readJSON('package.json').version);
+  }
+
+  function taskFixIgnore() {
+    var dir = grunt.config('boilerplateDest') + '/';
+    grunt.file.copy(dir + '.npmignore', dir + '.gitignore');
+    grunt.file.delete(dir + '.npmignore', { force: true });
+  }
+
+  function taskNew(dir) {
+    dir = grunt.option('cwd') + dir;
+    if (!dir) {
+      grunt.fail.fatal('Please specify a folder.');
+    } else if (dir.indexOf('.') === -1 && grunt.file.exists(dir)) {
+      grunt.fail.fatal('The folder "' + dir + '" must not exist.');
+    } else {
+      grunt.config('boilerplateDest', dir);
+      grunt.task.run('copy:boilerplate');
+      grunt.task.run('fixIgnore');
     }
+  }
 
-    function taskFixIgnore() {
-        var dir = grunt.config('boilerplateDest') + '/';
-        grunt.file.copy(dir + '.npmignore', dir + '.gitignore');
-        grunt.file.delete(dir + '.npmignore', { force: true });
+  // Load necessary modules
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-bump');
+
+  // Register our tasks
+  grunt.registerTask(
+    'cliversion',
+    'Displays the current installed cli version',
+    taskCliVersion
+  );
+
+  grunt.registerTask(
+    'deploy',
+    'Deploys the current project',
+    function (arg) {
+      exec('bash ' + grunt.option('cli') + 'scripts/deploy.sh', {
+        cwd: path.resolve(),
+        stdio: 'inherit'
+      });
     }
+  );
 
-    function taskNew(dir) {
-        dir = grunt.option('cwd') + dir;
-        if (!dir) {
-            grunt.fail.fatal('Please specify a folder.');
-        } else if (dir.indexOf('.') === -1 && grunt.file.exists(dir)) {
-            grunt.fail.fatal('The folder "' + dir + '" must not exist.');
-        } else {
-            grunt.config('boilerplateDest', dir);
-            grunt.task.run('copy:boilerplate');
-            grunt.task.run('fixIgnore');
-        }
+  grunt.registerTask(
+    'copyBuild',
+    'Copies the results of a Travis-CI build to the deploy branch',
+    function (arg) {
+      console.log(arg, this);
+      exec('bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
+        cwd: path.resolve(),
+        stdio: 'inherit'
+      });
     }
+  );
 
-    // Load necessary modules
-    grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-bump');
-    grunt.loadNpmTasks('grunt-shell');
+  grunt.registerTask(
+    'fixIgnore',
+    'Copies the npmignore file to a gitignore',
+    taskFixIgnore
+  );
 
-    // Register our tasks
-    grunt.registerTask(
-        'cliversion',
-        'Displays the current installed cli version',
-        taskCliVersion
-    );
+  grunt.registerTask(
+    'new',
+    'Create a new site using the STACHE boilerplate.',
+    taskNew
+  );
 
-    grunt.registerTask(
-        'deploy',
-        'Deploys the current project',
-        [
-            'cliversion',
-            'shell:deploy'
+  grunt.registerTask(
+    'release',
+    'Create a new release branch and commit to upstream.',
+    function (type) {
+      type = type || 'patch';
+      exec('grunt --base ' + grunt.option('cwd') + ' bump:' + type, {
+        cwd: path.resolve(),
+        stdio: 'inherit'
+      });
+    }
+  );
+
+  // Configure necessary modules
+  grunt.config.init({
+    bump: {
+      options: {
+        files: ['package.json'],
+        updateConfigs: [],
+        commit: true,
+        commitMessage: 'Release v%VERSION%',
+        commitFiles: ['package.json'],
+        createTag: false,
+        tagName: 'v%VERSION%',
+        tagMessage: 'Version %VERSION%',
+        push: true,
+        pushTo: 'origin',
+        gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+        globalReplace: false,
+        prereleaseName: false,
+        metadata: '',
+        regExp: false
+      }
+    },
+    copy: {
+      boilerplate: {
+        files: [
+          {
+            dot: true,
+            expand: true,
+            cwd: 'stache-boilerplate/',
+            src: '**',
+            dest: '<%= boilerplateDest %>'
+          }
         ]
-    );
-
-    grunt.registerTask(
-        'copyBuild',
-        'Copies the results of a Travis-CI build to the deploy branch',
-        [
-            'cliversion',
-            'shell:copyBuild'
-        ]
-    );
-
-    grunt.registerTask(
-        'fixIgnore',
-        'Copies the npmignore file to a gitignore',
-        taskFixIgnore
-    );
-
-    grunt.registerTask(
-        'new',
-        'Create a new site using the STACHE boilerplate.',
-        taskNew
-    );
-
-    grunt.registerTask(
-        'release',
-        'Create a new release branch and commit to upstream.',
-        function (type) {
-            type = type || 'patch';
-            exec('grunt --base ' + grunt.option('cwd') + ' bump:' + type, {
-                cwd: path.resolve(),
-                stdio: 'inherit'
-            });
-        }
-    );
-
-    // Configure necessary modules
-    grunt.config.init({
-        bump: {
-            options: {
-                files: ['package.json'],
-                updateConfigs: [],
-                commit: true,
-                commitMessage: 'Release v%VERSION%',
-                commitFiles: ['package.json'],
-                createTag: false,
-                tagName: 'v%VERSION%',
-                tagMessage: 'Version %VERSION%',
-                push: true,
-                pushTo: 'origin',
-                gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
-                globalReplace: false,
-                prereleaseName: false,
-                metadata: '',
-                regExp: false
-            }
-        },
-        shell: {
-            options: {
-                execOptions: {
-                    cwd: grunt.option('cwd'),
-                    stdout: true
-                }
-            },
-            copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
-            deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh'
-        },
-        copy: {
-            boilerplate: {
-                files: [
-                    {
-                        dot: true,
-                        expand: true,
-                        cwd: 'stache-boilerplate/',
-                        src: '**',
-                        dest: '<%= boilerplateDest %>'
-                    }
-                ]
-            }
-        }
-    });
+      }
+    }
+  });
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -61,6 +61,7 @@ module.exports = function (grunt) {
 
       if (filePath) {
         config = grunt.file.readYAML(filePath);
+        console.log("CONFIG:", config);
         for (k in config.env) {
           if (config.env.hasOwnProperty(k)) {
             env.push(k + '=' + config.env[k]);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -106,7 +106,7 @@ module.exports = function (grunt) {
             },
             copyBuild: 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh',
             deploy: 'bash ' + grunt.option('cli') + 'scripts/deploy.sh',
-            release: 'echo "Hello, World!" && grunt --gruntfile ' + path.resolve() + '/gruntfile.js bump',
+            release: 'echo "Hello, World!" && grunt --gruntfile ' + path.resolve() + '/gruntfile.js --base ' + grunt.option('cwd') + ' bump',
         },
         copy: {
             boilerplate: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -70,7 +70,8 @@ module.exports = function (grunt) {
         'release',
         'Create a new release branch and commit to upstream.',
         [
-            'shell:release'
+            'shell:release',
+            'bump'
         ]
     );
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -65,6 +65,7 @@ module.exports = function (grunt) {
         envStr += ' ';
       }
       console.log("ENV: ", envStr);
+      console.log("Typeof:", typeof exec);
       exec('echo "Hello, World!"');
       exec(envStr + 'bash ' + grunt.option('cli') + 'scripts/copy-build.sh', {
         cwd: path.resolve(),

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.2.0",
-    "grunt-contrib-copy": "^1.0.0"
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-shell": "^1.3.1"
   },
   "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "url": "https://github.com/blackbaud/stache-cli/issues"
   },
   "dependencies": {
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-copy": "^0.8.0",
-    "grunt-shell": "^1.1.2"
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-shell": "^1.3.1"
   },
   "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-shell": "^1.3.1"
+    "grunt-shell": "^1.3.1",
+    "merge": "^1.2.0"
   },
   "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "name": "Blackbaud - Bobby Earl"
   },
   "name": "blackbaud-stache-cli",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Blackbuad Stache CLI",
   "private": false,
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.2.0",
-    "grunt-contrib-copy": "^1.0.0",
-    "grunt-shell": "^1.3.1"
+    "grunt-contrib-copy": "^1.0.0"
   },
   "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "name": "Blackbaud - Bobby Earl"
   },
   "name": "blackbaud-stache-cli",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Blackbuad Stache CLI",
   "private": false,
   "preferGlobal": true,
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "grunt": "^0.4.5",
+    "grunt-bump": "^0.8.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-shell": "^1.1.2"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -39,7 +39,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     # push to STACHE_DEPLOY_TEST_BRANCH
     git add --all
     git stash
-    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    git checkout -b $STACHE_DEPLOY_TEST_BRANCH
     rm -rf $STACHE_BUILD_DIRECTORY
     git stash apply
     git add --all
@@ -54,7 +54,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
         git status
-        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        git checkout -b $STACHE_DEPLOY_PROD_BRANCH
         git merge $STACHE_DEPLOY_TEST_BRANCH --force
         git status
         git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -3,6 +3,9 @@
 # Fail the build if this step fails
 set -e
 
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}";
+echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+
 if [[ $TRAVIS_BRANCH == 'master' ]]; then
 
     if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -20,7 +20,10 @@ if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
     # Does the commit message match the appropriate pattern?
     if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
-      IS_RELEASE=true;
+
+      if [[ $TRAVIS_TAG ]]; then
+        IS_RELEASE=true;
+      fi
     fi
   fi
 fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -7,7 +7,21 @@ echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}";
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 
 if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; then
-    echo "Commit and push to ${TRAVIS_BRANCH}"
+    echo "Commit and push to feature-test..."
+
+    git config --global user.email "stache-build-user@blackbaud.com"
+    git config --global user.name "Blackbaud Stache Build User"
+
+    git stash
+    git rm -rf build
+    git stash pop
+    git add --all
+    git status
+
+    if ! git diff-index --quiet HEAD --; then
+        git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+        git push -fq origin feature-test
+    fi
 fi
 
 # if [[ $TRAVIS_BRANCH == 'master' ]]; then

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -19,6 +19,7 @@ if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; th
     rm -rf build
     git stash pop
     git add --all
+    git status
 
     if ! git diff-index --quiet HEAD --; then
         git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -4,7 +4,6 @@
 set -e
 
 IS_RELEASE=false
-echo "TRAVIS_COMMIT: ${TRAVIS_COMMIT}"
 LAST_COMMIT_MESSAGE=`git log --format=%B -n 1 $TRAVIS_COMMIT`
 
 # Regex matches 'Release vX.X.X' format
@@ -13,10 +12,12 @@ REGEX_RELEASE_COMMENT="^Release v[0-9]+\.[0-9]+\.[0-9]+"
 # Regex matches master,rc-,release
 REGEX_RELEASE_BRANCH="^(master|rc-|release)"
 
-# Is it a git push?
+# Is this commit requesting a release to production?
 if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+
   # Is the current branch a release-able branch?
   if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
+
     # Does the commit message match the appropriate pattern?
     if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
       IS_RELEASE=true;
@@ -33,59 +34,27 @@ echo "IS_RELEASE: ${IS_RELEASE}"
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
+    git config --global user.email "stache-build-user@blackbaud.com"
+    git config --global user.name "Blackbaud Stache Build User"
+
     # push to DEPLOY_TEST_BRANCH
-    echo "push to deploy test branch ${STACHE_DEPLOY_TEST_BRANCH}"
+    echo "Pushing to deployment test branch, ${STACHE_DEPLOY_TEST_BRANCH}..."
+    git add --all
+    git stash
+    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    rm -rf build
+    git stash pop
+    git add --all
+    git status
 
-    if [[ "$IS_RELEASE" == "true" ]]; then
+    if ! git diff-index --quiet HEAD --; then
+      git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+      git push -fq origin $STACHE_DEPLOY_TEST_BRANCH
 
-      # push to DEPLOY_PROD_BRANCH
-      echo "push to deploy prod branch ${STACHE_DEPLOY_PROD_BRANCH}"
+      if [[ "$IS_RELEASE" == "true" ]]; then
+        echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
+        git push -fq origin $STACHE_DEPLOY_PROD_BRANCH
+      fi
     fi
   fi
 fi
-
-# echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
-# echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
-#
-#
-# if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; then
-#     echo "Commit and push to feature-test..."
-#
-#     git config --global user.email "stache-build-user@blackbaud.com"
-#     git config --global user.name "Blackbaud Stache Build User"
-#
-#     git add --all
-#     git stash
-#     git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
-#     rm -rf build
-#     git stash pop
-#     git add --all
-#     git status
-#
-#     if ! git diff-index --quiet HEAD --; then
-#         git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-#         git push -fq origin $STACHE_DEPLOY_BRANCH
-#     fi
-# fi
-#
-# # if [[ $TRAVIS_BRANCH == 'master' ]]; then
-# #
-# #     if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
-# #
-# #         git config --global user.email "stache-build-user@blackbaud.com"
-# #         git config --global user.name "Blackbaud Stache Build User"
-# #
-# #         git add --all
-# #         git stash
-# #         git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
-# #         rm -rf build
-# #         git stash pop
-# #         git add --all
-# #
-# #         if ! git diff-index --quiet HEAD --; then
-# #             git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-# #             git push -fq origin $STACHE_DEPLOY_BRANCH
-# #         fi
-# #
-# #     fi
-# # fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -57,9 +57,9 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
         git status
         git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        git merge --force $STACHE_DEPLOY_TEST_BRANCH
+        git merge -fq $STACHE_DEPLOY_TEST_BRANCH
         git status
-        git push --force origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH 
+        git push -fq origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH 
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -3,8 +3,6 @@
 # Fail the build if this step fails
 set -e
 
-echo "CUSTOM VAR: ${MY_CUSTOM_VAR}";
-
 IS_RELEASE=false
 LAST_COMMIT_MESSAGE=`git log --format=%B -n 1 $TRAVIS_COMMIT`
 
@@ -29,6 +27,7 @@ if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
   fi
 fi
 
+echo "MY_CUSTOM_VAR: ${MY_CUSTOM_VAR}"
 echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "IS_RELEASE: ${IS_RELEASE}"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -21,7 +21,7 @@ if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
     # Does the commit message match the appropriate pattern?
     if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
 
-      if [[ $TRAVIS_TAG ]]; then
+      if [[ ! -z $TRAVIS_TAG ]]; then
         IS_RELEASE=true;
       fi
     fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -41,7 +41,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     # push to STACHE_DEPLOY_TEST_BRANCH
     git add --all
     git stash
-    git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
     rm -rf $STACHE_DEPLOY_DIR
     git stash apply
     git add --all
@@ -56,7 +56,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
         git status
-        git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
         git merge $STACHE_DEPLOY_TEST_BRANCH --force
         git status
         git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -6,24 +6,28 @@ set -e
 echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}";
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 
-if [[ $TRAVIS_BRANCH == 'master' ]]; then
-
-    if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
-
-        git config --global user.email "stache-build-user@blackbaud.com"
-        git config --global user.name "Blackbaud Stache Build User"
-
-        git add --all
-        git stash
-        git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
-        rm -rf build
-        git stash pop
-        git add --all
-
-        if ! git diff-index --quiet HEAD --; then
-            git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-            git push -fq origin $STACHE_DEPLOY_BRANCH
-        fi
-
-    fi
+if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; then
+    echo "Commit and push to ${TRAVIS_BRANCH}"
 fi
+
+# if [[ $TRAVIS_BRANCH == 'master' ]]; then
+#
+#     if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
+#
+#         git config --global user.email "stache-build-user@blackbaud.com"
+#         git config --global user.name "Blackbaud Stache Build User"
+#
+#         git add --all
+#         git stash
+#         git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
+#         rm -rf build
+#         git stash pop
+#         git add --all
+#
+#         if ! git diff-index --quiet HEAD --; then
+#             git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+#             git push -fq origin $STACHE_DEPLOY_BRANCH
+#         fi
+#
+#     fi
+# fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Fail the build if this step fails
+set -e
+
+if [[ $TRAVIS_BRANCH == 'master' ]]; then
+
+    if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
+
+        git config --global user.email "stache-build-user@blackbaud.com"
+        git config --global user.name "Blackbaud Stache Build User"
+
+        git add --all
+        git stash
+        git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
+        rm -rf build
+        git stash pop
+        git add --all
+
+        if ! git diff-index --quiet HEAD --; then
+            git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+            git push -fq origin $STACHE_DEPLOY_BRANCH
+        fi
+
+    fi
+fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -41,7 +41,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     # push to STACHE_DEPLOY_TEST_BRANCH
     git add --all
     git stash
-    git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
     rm -rf $STACHE_DEPLOY_DIR
     git stash apply
     git add --all
@@ -56,10 +56,10 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
         git status
-        git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        git merge -fq $STACHE_DEPLOY_TEST_BRANCH
+        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        git merge $STACHE_DEPLOY_TEST_BRANCH --force
         git status
-        git push -fq origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH 
+        git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -32,8 +32,8 @@ echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "IS_RELEASE: ${IS_RELEASE}"
 
-# Push commits to deploy branches.
-if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+# Push commits to deploy branches if we're on the master branch, or if it's a release.
+if [ "$TRAVIS_BRANCH" == "master" ] || [ "$IS_RELEASE" == "true" ]; then
   if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
     git config --global user.email "stache-build-user@blackbaud.com"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -17,6 +17,8 @@ if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; th
     git status
     git stash
 
+    git checkout feature-test
+
     if test -d build; then
         git rm -rf build
     fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -3,6 +3,8 @@
 # Fail the build if this step fails
 set -e
 
+echo "CUSTOM VAR: ${MY_CUSTOM_VAR}";
+
 IS_RELEASE=false
 LAST_COMMIT_MESSAGE=`git log --format=%B -n 1 $TRAVIS_COMMIT`
 

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -14,18 +14,6 @@ if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; th
     git config --global user.name "Blackbaud Stache Build User"
 
     git add --all
-    git status
-    git stash
-
-    git checkout feature-test
-
-    if test -d build; then
-        git rm -rf build
-    fi
-
-    git stash pop
-    git add --all
-    git status
 
     if ! git diff-index --quiet HEAD --; then
         git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -25,10 +25,10 @@ echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "IS_RELEASE: ${IS_RELEASE}"
 
-if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
-    # push to $DEPLOY_TEST_BRANCH
-    if [[ $IS_RELEASE == 'true' ]]; then
-        # push to $DEPLOY_PROD_BRANCH
+if [[ $TRAVIS_EVENT_TYPE == "push" ]]; then
+    # push to DEPLOY_TEST_BRANCH
+    if [[ $IS_RELEASE == "true" ]]; then
+        # push to DEPLOY_PROD_BRANCH
     fi
 fi
 

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -55,7 +55,9 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
           echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
-          git push --force origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH
+          git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+          git merge $STACHE_DEPLOY_TEST_BRANCH
+          git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
         fi
       fi
     fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -14,10 +14,15 @@ if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; th
     git config --global user.name "Blackbaud Stache Build User"
 
     git add --all
+    git stash
+    git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
+    rm -rf build
+    git stash pop
+    git add --all
 
     if ! git diff-index --quiet HEAD --; then
         git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-        git push -fq origin feature-test
+        git push -fq origin $STACHE_DEPLOY_BRANCH
     fi
 fi
 

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -12,7 +12,7 @@ REGEX_RELEASE_COMMENT="^Release v[0-9]+\.[0-9]+\.[0-9]+"
 # Regex matches master,rc-,release
 REGEX_RELEASE_BRANCH="^(master|rc-|release)"
 
-if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
         if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
             IS_RELEASE=true;
@@ -25,10 +25,12 @@ echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "IS_RELEASE: ${IS_RELEASE}"
 
-if [[ $TRAVIS_EVENT_TYPE == "push" ]]; then
+if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
     # push to DEPLOY_TEST_BRANCH
-    if [[ $IS_RELEASE == "true" ]]; then
+    echo "push to deploy test branch."
+    if [[ "$IS_RELEASE" == "true" ]]; then
         # push to DEPLOY_PROD_BRANCH
+        echo "push to deploy prod branch"
     fi
 fi
 

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -3,8 +3,9 @@
 # Fail the build if this step fails
 set -e
 
-echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}";
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+
 
 if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; then
     echo "Commit and push to feature-test..."
@@ -12,6 +13,7 @@ if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; th
     git config --global user.email "stache-build-user@blackbaud.com"
     git config --global user.name "Blackbaud Stache Build User"
 
+    git status
     git stash
     git rm -rf build
     git stash pop

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -12,12 +12,15 @@ REGEX_RELEASE_COMMENT="^Release v[0-9]+\.[0-9]+\.[0-9]+"
 # Regex matches master,rc-,release
 REGEX_RELEASE_BRANCH="^(master|rc-|release)"
 
-if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
-        if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
-            IS_RELEASE=true;
-        fi
+# Is it a git push?
+if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+  # Is the current branch a release-able branch?
+  if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
+    # Does the commit message match the appropriate pattern?
+    if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
+      IS_RELEASE=true;
     fi
+  fi
 fi
 
 echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
@@ -25,15 +28,16 @@ echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "IS_RELEASE: ${IS_RELEASE}"
 
+# Push commits to deploy branches.
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-    if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
-        # push to DEPLOY_TEST_BRANCH
-        echo "push to deploy test branch."
-        if [[ "$IS_RELEASE" == "true" ]]; then
-            # push to DEPLOY_PROD_BRANCH
-            echo "push to deploy prod branch"
-        fi
+  if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+    # push to DEPLOY_TEST_BRANCH
+    echo "push to deploy test branch ${stache.DEPLOY_TEST_BRANCH}"
+    if [[ "$IS_RELEASE" == "true" ]]; then
+      # push to DEPLOY_PROD_BRANCH
+      echo "push to deploy prod branch ${stache.DEPLOY_PROD_BRANCH}"
     fi
+  fi
 fi
 
 # echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -54,15 +54,8 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
 
       # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
-        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        rm -rf build
-        git stash pop
-        git add --all
-        git status
-        if ! git diff-index --quiet HEAD --; then
           echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
-          git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-          git push -fq origin $STACHE_DEPLOY_PROD_BRANCH
+          git push --force origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH
         fi
       fi
     fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -3,48 +3,77 @@
 # Fail the build if this step fails
 set -e
 
-echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
-echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+IS_RELEASE=false
+LAST_COMMIT_MESSAGE=`git log --format=%B -n 1 $TRAVIS_COMMIT`
 
+# Regex matches 'Release vX.X.X' format
+REGEX_RELEASE_COMMENT="^Release v[0-9]+\.[0-9]+\.[0-9]+"
 
-if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; then
-    echo "Commit and push to feature-test..."
+# Regex matches master,rc-,release
+REGEX_RELEASE_BRANCH="^(master|rc-|release)"
 
-    git config --global user.email "stache-build-user@blackbaud.com"
-    git config --global user.name "Blackbaud Stache Build User"
-
-    git add --all
-    git stash
-    git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
-    rm -rf build
-    git stash pop
-    git add --all
-    git status
-
-    if ! git diff-index --quiet HEAD --; then
-        git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-        git push -fq origin $STACHE_DEPLOY_BRANCH
+if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+    if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
+        if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
+            IS_RELEASE=true;
+        fi
     fi
 fi
 
-# if [[ $TRAVIS_BRANCH == 'master' ]]; then
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
+echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+echo "TRAVIS_TAG: ${TRAVIS_TAG}"
+echo "IS_RELEASE: ${IS_RELEASE}"
+
+if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
+    # push to $DEPLOY_TEST_BRANCH
+    if [[ $IS_RELEASE ]]; then
+        # push to $DEPLOY_PROD_BRANCH
+    fi
+fi
+
+# echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
+# echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 #
-#     if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
 #
-#         git config --global user.email "stache-build-user@blackbaud.com"
-#         git config --global user.name "Blackbaud Stache Build User"
+# if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; then
+#     echo "Commit and push to feature-test..."
 #
-#         git add --all
-#         git stash
-#         git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
-#         rm -rf build
-#         git stash pop
-#         git add --all
+#     git config --global user.email "stache-build-user@blackbaud.com"
+#     git config --global user.name "Blackbaud Stache Build User"
 #
-#         if ! git diff-index --quiet HEAD --; then
-#             git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-#             git push -fq origin $STACHE_DEPLOY_BRANCH
-#         fi
+#     git add --all
+#     git stash
+#     git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
+#     rm -rf build
+#     git stash pop
+#     git add --all
+#     git status
 #
+#     if ! git diff-index --quiet HEAD --; then
+#         git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+#         git push -fq origin $STACHE_DEPLOY_BRANCH
 #     fi
 # fi
+#
+# # if [[ $TRAVIS_BRANCH == 'master' ]]; then
+# #
+# #     if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
+# #
+# #         git config --global user.email "stache-build-user@blackbaud.com"
+# #         git config --global user.name "Blackbaud Stache Build User"
+# #
+# #         git add --all
+# #         git stash
+# #         git checkout $STACHE_DEPLOY_BRANCH || git checkout -b $STACHE_DEPLOY_BRANCH
+# #         rm -rf build
+# #         git stash pop
+# #         git add --all
+# #
+# #         if ! git diff-index --quiet HEAD --; then
+# #             git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+# #             git push -fq origin $STACHE_DEPLOY_BRANCH
+# #         fi
+# #
+# #     fi
+# # fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -57,6 +57,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
         git checkout -b $STACHE_DEPLOY_PROD_BRANCH
         git merge $STACHE_DEPLOY_TEST_BRANCH
+        git status
         git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
       fi
     fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -55,8 +55,9 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
+        git status
         git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        git merge $STACHE_DEPLOY_TEST_BRANCH
+        git merge $STACHE_DEPLOY_TEST_BRANCH --force
         git status
         git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
       fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -4,6 +4,7 @@
 set -e
 
 IS_RELEASE=false
+echo "TRAVIS_COMMIT: ${TRAVIS_COMMIT}"
 LAST_COMMIT_MESSAGE=`git log --format=%B -n 1 $TRAVIS_COMMIT`
 
 # Regex matches 'Release vX.X.X' format

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -41,7 +41,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     # push to STACHE_DEPLOY_TEST_BRANCH
     git add --all
     git stash
-    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    git checkout -b $STACHE_DEPLOY_TEST_BRANCH
     rm -rf build
     git stash apply
     git add --all
@@ -54,11 +54,10 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
 
       # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
-          echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
-          git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-          git merge $STACHE_DEPLOY_TEST_BRANCH
-          git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
-        fi
+        echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
+        git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        git merge $STACHE_DEPLOY_TEST_BRANCH
+        git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -16,16 +16,15 @@ REGEX_RELEASE_BRANCH="^(master|rc-|release)"
 if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
   # Is the current branch a release-able branch?
-  if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
+  #if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
 
     # Does the commit message match the appropriate pattern?
     if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
-
       if [[ ! -z $TRAVIS_TAG ]]; then
         IS_RELEASE=true;
       fi
     fi
-  fi
+  #fi
 fi
 
 echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -37,23 +37,32 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     git config --global user.email "stache-build-user@blackbaud.com"
     git config --global user.name "Blackbaud Stache Build User"
 
-    # push to DEPLOY_TEST_BRANCH
-    echo "Pushing to deployment test branch, ${STACHE_DEPLOY_TEST_BRANCH}..."
+    # push to STACHE_DEPLOY_TEST_BRANCH
     git add --all
     git stash
     git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
     rm -rf build
-    git stash pop
+    git stash apply
     git add --all
     git status
 
     if ! git diff-index --quiet HEAD --; then
+      echo "Pushing to deployment test branch, ${STACHE_DEPLOY_TEST_BRANCH}..."
       git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
       git push -fq origin $STACHE_DEPLOY_TEST_BRANCH
 
+      # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
-        echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
-        git push -fq origin $STACHE_DEPLOY_PROD_BRANCH
+        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        rm -rf build
+        git stash pop
+        git add --all
+        git status
+        if ! git diff-index --quiet HEAD --; then
+          echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
+          git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+          git push -fq origin $STACHE_DEPLOY_PROD_BRANCH
+        fi
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -35,31 +35,31 @@ echo "IS_RELEASE: ${IS_RELEASE}"
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
-    git config --global user.email "stache-build-user@blackbaud.com"
-    git config --global user.name "Blackbaud Stache Build User"
-
-    # push to STACHE_DEPLOY_TEST_BRANCH
-    git add --all
-    git stash
-    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
-    rm -rf $STACHE_DEPLOY_DIR
-    git stash apply
-    git add --all
-    git status
+    # git config --global user.email "stache-build-user@blackbaud.com"
+    # git config --global user.name "Blackbaud Stache Build User"
+    #
+    # # push to STACHE_DEPLOY_TEST_BRANCH
+    # git add --all
+    # git stash
+    # git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    # rm -rf $STACHE_DEPLOY_DIR
+    # git stash apply
+    # git add --all
+    # git status
 
     if ! git diff-index --quiet HEAD --; then
       echo "Pushing to deployment test branch, ${STACHE_DEPLOY_TEST_BRANCH}..."
-      git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-      git push -fq origin $STACHE_DEPLOY_TEST_BRANCH
+      # git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+      # git push -fq origin $STACHE_DEPLOY_TEST_BRANCH
 
       # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
-        git status
-        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        git merge $STACHE_DEPLOY_TEST_BRANCH --force
-        git status
-        git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
+        # git status
+        # git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        # git merge $STACHE_DEPLOY_TEST_BRANCH --force
+        # git status
+        # git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -25,12 +25,14 @@ echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "IS_RELEASE: ${IS_RELEASE}"
 
-if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
-    # push to DEPLOY_TEST_BRANCH
-    echo "push to deploy test branch."
-    if [[ "$IS_RELEASE" == "true" ]]; then
-        # push to DEPLOY_PROD_BRANCH
-        echo "push to deploy prod branch"
+if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+    if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+        # push to DEPLOY_TEST_BRANCH
+        echo "push to deploy test branch."
+        if [[ "$IS_RELEASE" == "true" ]]; then
+            # push to DEPLOY_PROD_BRANCH
+            echo "push to deploy prod branch"
+        fi
     fi
 fi
 

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -20,14 +20,11 @@ if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
     # Does the commit message match the appropriate pattern?
     if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
-      #if [[ ! -z $TRAVIS_TAG ]]; then
       IS_RELEASE=true;
-      #fi
     fi
   fi
 fi
 
-echo "MY_CUSTOM_VAR: ${MY_CUSTOM_VAR}"
 echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "IS_RELEASE: ${IS_RELEASE}"
@@ -36,31 +33,31 @@ echo "IS_RELEASE: ${IS_RELEASE}"
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
-    # git config --global user.email "stache-build-user@blackbaud.com"
-    # git config --global user.name "Blackbaud Stache Build User"
-    #
-    # # push to STACHE_DEPLOY_TEST_BRANCH
-    # git add --all
-    # git stash
-    # git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
-    # rm -rf $STACHE_DEPLOY_DIR
-    # git stash apply
-    # git add --all
-    # git status
+    git config --global user.email "stache-build-user@blackbaud.com"
+    git config --global user.name "Blackbaud Stache Build User"
+
+    # push to STACHE_DEPLOY_TEST_BRANCH
+    git add --all
+    git stash
+    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    rm -rf $STACHE_DEPLOY_DIR
+    git stash apply
+    git add --all
+    git status
 
     if ! git diff-index --quiet HEAD --; then
       echo "Pushing to deployment test branch, ${STACHE_DEPLOY_TEST_BRANCH}..."
-      # git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
-      # git push -fq origin $STACHE_DEPLOY_TEST_BRANCH
+      git commit -am "Built via Travis Build #${TRAVIS_BUILD_NUMBER}"
+      git push -fq origin $STACHE_DEPLOY_TEST_BRANCH
 
       # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
-        # git status
-        # git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        # git merge $STACHE_DEPLOY_TEST_BRANCH --force
-        # git status
-        # git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
+        git status
+        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        git merge $STACHE_DEPLOY_TEST_BRANCH --force
+        git status
+        git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -32,11 +32,14 @@ echo "IS_RELEASE: ${IS_RELEASE}"
 # Push commits to deploy branches.
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+
     # push to DEPLOY_TEST_BRANCH
-    echo "push to deploy test branch ${stache.DEPLOY_TEST_BRANCH}"
+    echo "push to deploy test branch ${STACHE_DEPLOY_TEST_BRANCH}"
+
     if [[ "$IS_RELEASE" == "true" ]]; then
+
       # push to DEPLOY_PROD_BRANCH
-      echo "push to deploy prod branch ${stache.DEPLOY_PROD_BRANCH}"
+      echo "push to deploy prod branch ${STACHE_DEPLOY_PROD_BRANCH}"
     fi
   fi
 fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -16,24 +16,23 @@ REGEX_RELEASE_BRANCH="^(master|rc-|release)"
 if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
   # Is the current branch a release-able branch?
-  #if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
+  if [[ $TRAVIS_BRANCH =~ $REGEX_RELEASE_BRANCH ]]; then
 
     # Does the commit message match the appropriate pattern?
     if [[ $LAST_COMMIT_MESSAGE =~ $REGEX_RELEASE_COMMENT ]]; then
-      if [[ ! -z $TRAVIS_TAG ]]; then
-        IS_RELEASE=true;
-      fi
+      #if [[ ! -z $TRAVIS_TAG ]]; then
+      IS_RELEASE=true;
+      #fi
     fi
-  #fi
+  fi
 fi
 
 echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
-echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "IS_RELEASE: ${IS_RELEASE}"
 
 # Push commits to deploy branches if we're on the master branch, or if it's a release.
-if [ "$TRAVIS_BRANCH" == "master" ] || [ "$IS_RELEASE" == "true" ]; then
+if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
 
     git config --global user.email "stache-build-user@blackbaud.com"

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -53,11 +53,11 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       # Push to STACHE_DEPLOY_PROD_BRANCH
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
-        git status
         git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        git merge $STACHE_DEPLOY_TEST_BRANCH --force
+        git merge $STACHE_DEPLOY_TEST_BRANCH
         git status
-        git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
+        git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH
+        git status
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -13,9 +13,14 @@ if [[ $TRAVIS_BRANCH == 'develop' && $TRAVIS_EVENT_TYPE == 'pull_request' ]]; th
     git config --global user.email "stache-build-user@blackbaud.com"
     git config --global user.name "Blackbaud Stache Build User"
 
+    git add --all
     git status
     git stash
-    git rm -rf build
+
+    if test -d build; then
+        git rm -rf build
+    fi
+
     git stash pop
     git add --all
     git status

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -41,7 +41,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     # push to STACHE_DEPLOY_TEST_BRANCH
     git add --all
     git stash
-    git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
+    git checkout -b $STACHE_DEPLOY_TEST_BRANCH
     rm -rf $STACHE_DEPLOY_DIR
     git stash apply
     git add --all
@@ -56,10 +56,10 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       if [[ "$IS_RELEASE" == "true" ]]; then
         echo "Pushing to deployment production branch, ${STACHE_DEPLOY_PROD_BRANCH}..."
         git status
-        git checkout $STACHE_DEPLOY_PROD_BRANCH || git checkout -b $STACHE_DEPLOY_PROD_BRANCH
-        git merge $STACHE_DEPLOY_TEST_BRANCH --force
+        git checkout -b $STACHE_DEPLOY_PROD_BRANCH
+        git merge --force $STACHE_DEPLOY_TEST_BRANCH
         git status
-        git push origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH --force
+        git push --force origin $STACHE_DEPLOY_TEST_BRANCH:$STACHE_DEPLOY_PROD_BRANCH 
       fi
     fi
   fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -27,7 +27,7 @@ echo "IS_RELEASE: ${IS_RELEASE}"
 
 if [[ $TRAVIS_EVENT_TYPE == 'push' ]]; then
     # push to $DEPLOY_TEST_BRANCH
-    if [[ $IS_RELEASE ]]; then
+    if [[ $IS_RELEASE == 'true' ]]; then
         # push to $DEPLOY_PROD_BRANCH
     fi
 fi

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -40,7 +40,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     git add --all
     git stash
     git checkout $STACHE_DEPLOY_TEST_BRANCH || git checkout -b $STACHE_DEPLOY_TEST_BRANCH
-    rm -rf $STACHE_DEPLOY_DIR
+    rm -rf $STACHE_BUILD_DIRECTORY
     git stash apply
     git add --all
     git status

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -42,7 +42,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     git add --all
     git stash
     git checkout -b $STACHE_DEPLOY_TEST_BRANCH
-    rm -rf build
+    rm -rf $STACHE_DEPLOY_DIR
     git stash apply
     git add --all
     git status

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -85,9 +85,14 @@ build() {
 
 # Syncs the stache build output to the deployment target
 sync() {
-  "$KUDU_SYNC_CMD" -v 500 -f "$DEPLOYMENT_SOURCE/build" -t "$DEPLOYMENT_TARGET" -n "$NEXT_MANIFEST_PATH" -p "$PREVIOUS_MANIFEST_PATH" -i ".git;.hg;.deployment;deploy.sh"
+  "$KUDU_SYNC_CMD" -v 500 -f "$DEPLOYMENT_SOURCE/$STACHE_BUILD_DIRECTORY" -t "$DEPLOYMENT_TARGET" -n "$NEXT_MANIFEST_PATH" -p "$PREVIOUS_MANIFEST_PATH" -i ".git;.hg;.deployment;deploy.sh"
   exitWithMessageOnError "Kudu Sync to Target failed"
 }
+
+# Set the build directory
+if [[ ! -n "$STACHE_BUILD_DIRECTORY" ]]; then
+  STACHE_BUILD_DIRECTORY="build"
+fi
 
 # MAIN ENTRY POINT
 notifySlack "Stache build started."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -92,8 +92,12 @@ sync() {
 # MAIN ENTRY POINT
 notifySlack "Stache build started."
 selectNodeVersion
-install
-build
+
+# Only run install and build if Travis-CI hasn't done it already.
+if [ ! -e "$DEPLOYMENT_SOURCE/.travis.yml" ]; then
+  install
+  build
+fi
+
 sync
 notifySlack "Stache build successfully completed."
-# MAIN ENTRY POINT

--- a/stache-boilerplate/.gitignore
+++ b/stache-boilerplate/.gitignore
@@ -2,6 +2,5 @@
 .tmp/
 Thumbs.db
 vendor/
-build/
 serve/
 node_modules/

--- a/stache-boilerplate/.travis.yml-sample
+++ b/stache-boilerplate/.travis.yml-sample
@@ -1,17 +1,18 @@
 language: node_js
 
 before_script:
-  - npm install -g grunt-cli blackbaud-stache-cli
+  - npm i -g grunt-cli blackbaud-stache-cli
 
 script:
-  - grunt build --config=stache.yml,stache.prod.yml
+  - stache build --config=stache.yml,stache.prod.yml,stache.deploy.yml
 
 after_success:
-  - stache copyBuild
-
-env:
-  - STACHE_DEPLOY_BRANCH=deploy
+  - stache copyBuild --config=$TRAVIS_BUILD_DIR/stache.deploy.yml
 
 cache:
   directories:
     - node_modules
+
+branches:
+  except:
+    - deploy

--- a/stache-boilerplate/.travis.yml-sample
+++ b/stache-boilerplate/.travis.yml-sample
@@ -1,0 +1,17 @@
+language: node_js
+
+before_script:
+  - npm install -g grunt-cli blackbaud-stache-cli
+
+script:
+  - grunt build --config=stache.yml,stache.prod.yml
+
+after_success:
+  - stache copyBuild
+
+env:
+  - STACHE_DEPLOY_BRANCH=deploy
+
+cache:
+  directories:
+    - node_modules

--- a/stache.deploy.yml
+++ b/stache.deploy.yml
@@ -1,5 +1,5 @@
-build: deploy/
 env:
-  STACHE_DEPLOY_TEST_BRANCH: deploy-test
-  STACHE_DEPLOY_PROD_BRANCH: deploy-prod
-  STACHE_DEPLOY_DIR: deploy
+  STACHE_DEPLOY_TEST_BRANCH: deploy
+  STACHE_DEPLOY_PROD_BRANCH: deploy
+  STACHE_BUILD_DIRECTORY: deploy
+build: <%= stache.config.env.STACHE_BUILD_DIRECTORY %>/

--- a/stache.deploy.yml
+++ b/stache.deploy.yml
@@ -1,0 +1,5 @@
+build: deploy/
+env:
+  STACHE_DEPLOY_TEST_BRANCH: deploy-test
+  STACHE_DEPLOY_PROD_BRANCH: deploy-prod
+  STACHE_DEPLOY_DIR: deploy


### PR DESCRIPTION
@Blackbaud-BobbyEarl, @blackbaud-brandonhare, thoughts?

**Purpose:**
Azure, instead of building the site from scratch, should deploy from the repository's `build` directory, generated by Travis-CI. If the site needs to be locked down behind a Blackbaud login, this method requires the use of BBAUTH and DLL files. (It might be a good idea to create a different Stache boilerplate that contains the DLL files.)

Eventually, all sites on the internal network will be migrated to Azure; however, the deployment structure for internal sites should remain untouched. 

**There are three branches:**
- `master` (production-ready state)
- `deploy` (CI engine watches this branch)
- `feature-` (deleted after merging into master)

**The workflow:**
1. Create `feature` branch off `master`
2. Create pull request `master` <== `feature`
3. Travis runs tests
4. Merge `feature` into `master`
5. Push to Github triggers Travis to build and commit into `deploy` branch
6. Azure watches `deploy` branch and redeploys from `build` directory

**How to setup a site to use Azure deployments:**
1. Make sure the `build` directory is removed from `.gitignore`
2. Copy the `.travis.yml` file from [travis-docs repo](https://github.com/blackbaud/travis-docs)
3. Copy the DLL files from [travis-docs/static/bin](https://github.com/blackbaud/travis-docs/tree/master/static/bin)
4. Activate the GitHub repository to use Travis-CI
5. Login to Azure portal and create a new App Service, configuring the deployment source to watch the `deploy` branch
6. You’re done!
